### PR TITLE
[feat] OAuth 리프레시 토큰 연동

### DIFF
--- a/src/main/java/com/back/domain/user/service/UserAuthService.java
+++ b/src/main/java/com/back/domain/user/service/UserAuthService.java
@@ -87,8 +87,8 @@ public class UserAuthService {
 
     // 리프레시 토큰 관련
 
-    public void issueTokens(HttpServletResponse response, Long userId, String email) {
-        String accessToken = jwtUtil.generateAccessToken(userId, email);
+    public void issueTokens(HttpServletResponse response, Long userId, String email, String nickname) {
+        String accessToken = jwtUtil.generateAccessToken(userId, email, nickname);
         String refreshToken = refreshTokenService.generateRefreshToken(userId, email);
 
         jwtUtil.addAccessTokenToCookie(response, accessToken);
@@ -112,8 +112,15 @@ public class UserAuthService {
             Long userId = refreshTokenEntity.getUserId();
             String email = refreshTokenEntity.getEmail();
 
+            // DB에서 현재 nickname 조회
+            Optional<User> user = userRepository.findById(userId);
+            if (user.isEmpty()) {
+                return false;
+            }
+            String nickname = user.get().getNickname();
+
             String newRefreshToken = refreshTokenService.rotateToken(oldRefreshToken);
-            String newAccessToken = jwtUtil.generateAccessToken(userId, email);
+            String newAccessToken = jwtUtil.generateAccessToken(userId, email, nickname);
 
             jwtUtil.addAccessTokenToCookie(response, newAccessToken);
             jwtUtil.addRefreshTokenToCookie(response, newRefreshToken);

--- a/src/main/java/com/back/global/jwt/JwtUtil.java
+++ b/src/main/java/com/back/global/jwt/JwtUtil.java
@@ -28,13 +28,14 @@ public class JwtUtil {
         this.accessTokenExpiration = accessTokenExpiration * 1000;
     }
 
-    public String generateAccessToken(Long userId, String email) {
+    public String generateAccessToken(Long userId, String email, String nickname) {
         Date now = new Date();
         Date expiration = new Date(now.getTime() + accessTokenExpiration);
 
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("email", email)
+                .claim("nickname", nickname)
                 .issuedAt(now)
                 .expiration(expiration)
                 .signWith(secretKey)
@@ -50,17 +51,6 @@ public class JwtUtil {
         response.addCookie(cookie);
     }
 
-    public String getAccessTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
-    }
 
     public void removeAccessTokenCookie(HttpServletResponse response) {
         Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);

--- a/src/main/java/com/back/global/rq/Rq.java
+++ b/src/main/java/com/back/global/rq/Rq.java
@@ -48,7 +48,7 @@ public class Rq {
                     return User.builder()
                             .id(securityUser.getId())
                             .email(securityUser.getEmail())
-                            .nickname(securityUser.getName())
+                            .nickname(securityUser.getNickname())
                             .role(role)
                             .build();
                 })

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -116,7 +116,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 
         // accessToken이 만료됐으면 새로 발급
         if (isAccessTokenExists && !isAccessTokenValid) {
-            String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
+            String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail(), user.getNickname());
             rq.setCrossDomainCookie("accessToken", newAccessToken, accessTokenExpiration);
         }
 

--- a/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
@@ -26,7 +26,7 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
         SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
 
         // Access Token과 Refresh Token 발급
-        userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail());
+        userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail(), securityUser.getNickname());
 
         // 프론트엔드로 리다이렉트
         String redirectUrl = frontendUrl + "/oauth/success";

--- a/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
@@ -1,8 +1,6 @@
 package com.back.global.security;
 
-import com.back.domain.user.service.UserService;
-import com.back.global.jwt.JwtUtil;
-import com.back.global.rq.Rq;
+import com.back.domain.user.service.UserAuthService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,14 +11,12 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
-    private final Rq rq;
-    private final JwtUtil jwtUtil;
-    private final UserService userService;
+
+    private final UserAuthService userAuthService;
 
     @Value("${FRONTEND_URL}")
     private String frontendUrl;
@@ -29,11 +25,8 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
 
-        // Access Token 생성
-        String accessToken = jwtUtil.generateAccessToken(securityUser.getId(), securityUser.getEmail());
-
-        // 쿠키에 토큰 저장
-        rq.setCrossDomainCookie("accessToken", accessToken, (int) TimeUnit.MINUTES.toSeconds(20));
+        // Access Token과 Refresh Token 발급
+        userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail());
 
         // 프론트엔드로 리다이렉트
         String redirectUrl = frontendUrl + "/oauth/success";

--- a/src/main/java/com/back/global/security/SecurityUser.java
+++ b/src/main/java/com/back/global/security/SecurityUser.java
@@ -13,7 +13,7 @@ public class SecurityUser extends User implements OAuth2User {
     private Long id;
 
     @Getter
-    private String name;
+    private String nickname;
 
     @Getter
     private String email;
@@ -24,13 +24,13 @@ public class SecurityUser extends User implements OAuth2User {
     public SecurityUser(
             long id,
             String email,
-            String name,
+            String nickname,
             Collection<? extends GrantedAuthority> authorities,
             Map<String, Object> attributes
     ) {
         super(email, "", authorities); // OAuth2에서는 빈 패스워드
         this.id = id;
-        this.name = name;
+        this.nickname = nickname;
         this.email = email;
         this.attributes = attributes;
     }
@@ -42,6 +42,10 @@ public class SecurityUser extends User implements OAuth2User {
 
     @Override
     public String getName() {
-        return name; // OAuth2User 인터페이스용
+        return nickname; // OAuth2User 인터페이스용 - nickname 반환
+    }
+
+    public String getNickname() {
+        return getName();
     }
 }


### PR DESCRIPTION
## 📢 기능 설명

OAuth 로그인 플로우:

  1. OAuth 로그인 성공 → CustomOAuth2LoginSuccessHandler 호출
  2. 액세스 토큰 + 리프레시 토큰 동시 발급 (JWT에 nickname 포함)
  3. 두 토큰 모두 쿠키에 저장
  4. 프론트엔드로 리다이렉트

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #35 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
