### PR TITLE
[refactor] 프로필 메소드를 Patch로 변경 #53

### DIFF
--- a/src/main/java/com/back/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/back/domain/profile/controller/ProfileController.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/me/profile")
+@RequestMapping("/api/me/profile")
 @RequiredArgsConstructor
 public class ProfileController {
 
@@ -24,9 +24,14 @@ public class ProfileController {
         return RsData.successOf(body); // code=200, message="success"
     }
 
-    @PutMapping
-    public RsData<ProfileResponseDto> updateProfile(@AuthenticationPrincipal(expression = "id") Long userId, @Valid @RequestBody ProfileUpdateRequestDto profileUpdateRequestDto) {
-        ProfileResponseDto body = profileService.updateProfile(userId, profileUpdateRequestDto);
-        return RsData.successOf(body); // code=200
+    // PUT 제거: PATCH 전용으로 운영
+
+    @PatchMapping
+    public RsData<ProfileResponseDto> patchNickname(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @Valid @RequestBody ProfileUpdateRequestDto request
+    ) {
+        ProfileResponseDto body = profileService.updateProfile(userId, request);
+        return RsData.successOf(body);
     }
 }

--- a/src/main/java/com/back/domain/profile/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/back/domain/profile/dto/ProfileUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package com.back.domain.profile.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,7 +10,4 @@ public class ProfileUpdateRequestDto {
 
     @Size(min = 1, max = 10, message = "닉네임은 1~10자")
     private String nickname;
-
-    @Email(message = "이메일 형식이 아닙니다")
-    private String email;
 }

--- a/src/main/java/com/back/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/back/domain/profile/service/ProfileService.java
@@ -50,11 +50,6 @@ public class ProfileService {
             user.setNickname(nickname);
         }
 
-        if (profileUpdateRequestDto.getEmail() != null) {
-            String email = profileUpdateRequestDto.getEmail().trim();
-            user.setEmail(email.isEmpty() ? null : email);
-        }
-
         userRepository.save(user);
 
         return getProfile(id);


### PR DESCRIPTION
## 📢 기능 설명

프로필 메소드를 Patch로 변경
불필요한 이메일 관련 코드 정리
<br>

## 연결된 issue

close #53
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 프로필 `PUT` 메서드를 제거하고, 메소드를 Patch로 처리
- `ProfileController`의 기본 API 엔드포인트를 `/me/profile`에서 `/api/me/profile`로 변경
- 불필요한 이메일 관련 코드 정리

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
