### PR TITLE
[refactor] 카카오 리다이렉트 url 매핑 수정 & 배포 설정 변경

### DIFF
--- a/src/main/java/com/back/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/back/domain/notification/controller/NotificationController.java
@@ -2,6 +2,10 @@ package com.back.domain.notification.controller;
 
 import com.back.domain.notification.dto.NotificationGoResponseDto;
 import com.back.domain.notification.dto.NotificationListResponseDto;
+import com.back.domain.notification.dto.NotificationSettingDto;
+import com.back.domain.notification.service.NotificationSettingService;
+import com.back.domain.notification.dto.NotificationSettingUpdateRequestDto;
+import jakarta.validation.Valid;
 import com.back.domain.notification.service.NotificationService;
 import com.back.global.rsData.RsData;
 import jakarta.validation.constraints.Max;
@@ -21,6 +25,7 @@ import java.time.LocalDateTime;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
 
     @GetMapping("/notifications")
     public RsData<NotificationListResponseDto> getNotifications(
@@ -30,6 +35,23 @@ public class NotificationController {
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int limit
     ) {
         NotificationListResponseDto body = notificationService.getNotifications(userId, lastCreatedAt, lastId, limit);
+        return RsData.successOf(body);
+    }
+
+    @GetMapping("/notification-setting")
+    public RsData<NotificationSettingDto> getMyNotificationSetting(
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        NotificationSettingDto body = notificationSettingService.getMySetting(userId);
+        return RsData.successOf(body);
+    }
+
+    @PatchMapping("/notification-setting")
+    public RsData<NotificationSettingDto> setMyNotificationSetting(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @Valid @RequestBody NotificationSettingUpdateRequestDto req
+    ) {
+        NotificationSettingDto body = notificationSettingService.setMySetting(userId, req.enabled());
         return RsData.successOf(body);
     }
 

--- a/src/main/java/com/back/domain/notification/dto/NotificationSettingDto.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationSettingDto.java
@@ -1,0 +1,16 @@
+package com.back.domain.notification.dto;
+
+import com.back.domain.notification.entity.NotificationSetting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationSettingDto {
+    private boolean enabled;
+
+    public static NotificationSettingDto from(NotificationSetting s) {
+        return new NotificationSettingDto(s.isEnabled());
+    }
+}
+

--- a/src/main/java/com/back/domain/notification/dto/NotificationSettingUpdateRequestDto.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationSettingUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package com.back.domain.notification.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NotificationSettingUpdateRequestDto(
+        @NotNull Boolean enabled
+) {}
+

--- a/src/main/java/com/back/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/back/domain/notification/entity/NotificationSetting.java
@@ -1,0 +1,44 @@
+package com.back.domain.notification.entity;
+
+import com.back.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NotificationSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Setter
+    @Builder.Default
+    private boolean enabled = true;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public void toggle() {
+        this.enabled = !this.enabled;
+    }
+
+}

--- a/src/main/java/com/back/domain/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,18 @@
+package com.back.domain.notification.repository;
+
+import com.back.domain.notification.entity.NotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    @Query("""
+        select ns from NotificationSetting ns
+         where ns.user.id = :userId
+    """)
+    NotificationSetting findByUserId(@Param("userId") Long userId);
+}
+

--- a/src/main/java/com/back/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/com/back/domain/notification/service/NotificationSettingService.java
@@ -1,0 +1,46 @@
+package com.back.domain.notification.service;
+
+import com.back.domain.notification.dto.NotificationSettingDto;
+import com.back.domain.notification.entity.NotificationSetting;
+import com.back.domain.notification.repository.NotificationSettingRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationSettingDto getMySetting(Long userId) {
+        NotificationSetting s = notificationSettingRepository.findByUserId(userId);
+        if (s == null) {
+            // Default when not created yet
+            return new NotificationSettingDto(true);
+        }
+        return NotificationSettingDto.from(s);
+    }
+
+    @Transactional
+    public NotificationSettingDto setMySetting(Long userId, boolean enabled) {
+        NotificationSetting s = notificationSettingRepository.findByUserId(userId);
+        if (s == null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ServiceException(404, "사용자를 찾을 수 없습니다."));
+            s = NotificationSetting.builder()
+                    .user(user)
+                    .enabled(enabled)
+                    .build();
+        } else {
+            s.setEnabled(enabled);
+        }
+        NotificationSetting saved = notificationSettingRepository.save(s);
+        return NotificationSettingDto.from(saved);
+    }
+}

--- a/src/main/java/com/back/global/jwt/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/back/global/jwt/refreshToken/service/RefreshTokenService.java
@@ -25,6 +25,7 @@ public class RefreshTokenService {
     private long refreshTokenExpiration;
 
     // 기존 리프레시 토큰 삭제하고 생성
+    @Transactional
     public String generateRefreshToken(Long userId, String email) {
         // 기존 토큰 삭제
         refreshTokenRepository.deleteByUserId(userId);
@@ -53,6 +54,7 @@ public class RefreshTokenService {
     }
 
     //기존 토큰 지우고 발급(회전)
+    @Transactional
     public String rotateToken(String oldToken) {
         Optional<RefreshToken> oldRefreshToken = refreshTokenRepository.findByToken(oldToken);
 
@@ -67,6 +69,7 @@ public class RefreshTokenService {
     }
 
     //삭제
+    @Transactional
     public void revokeToken(String token) {
         refreshTokenRepository.deleteByToken(token);
     }

--- a/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
@@ -28,7 +28,7 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
         userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail(), securityUser.getNickname());
 
         // 프론트엔드로 리다이렉트
-        String redirectUrl = frontendUrl;
+        String redirectUrl = frontendUrl + "/oauth/success";
 
         response.sendRedirect(redirectUrl);
     }

--- a/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
@@ -26,6 +26,10 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
         SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
         // Access Token과 Refresh Token 발급
         userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail(), securityUser.getNickname());
-        response.sendRedirect(frontendUrl);
+
+        // 프론트엔드로 리다이렉트
+        String redirectUrl = frontendUrl;
+
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/back/global/security/CustomOAuth2LoginSuccessHandler.java
@@ -24,13 +24,8 @@ public class CustomOAuth2LoginSuccessHandler implements AuthenticationSuccessHan
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
-
         // Access Token과 Refresh Token 발급
         userAuthService.issueTokens(response, securityUser.getId(), securityUser.getEmail(), securityUser.getNickname());
-
-        // 프론트엔드로 리다이렉트
-        String redirectUrl = frontendUrl + "/oauth/success";
-
-        response.sendRedirect(redirectUrl);
+        response.sendRedirect(frontendUrl);
     }
 }

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.back.global.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -17,6 +18,12 @@ import java.util.Arrays;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Value("${custom.site.frontUrl}")
+    private String frontUrl;
+
+    @Value("${custom.site.backUrl}")
+    private String backUrl;
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2LoginSuccessHandler oauth2SuccessHandler;
@@ -46,18 +53,16 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/oauth2/**").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
-                        .requestMatchers("/api/user/**").permitAll()
-                        .requestMatchers("/api/cocktail/**").permitAll()
-                        .requestMatchers("/api/chatbot/**").permitAll()
-                        .requestMatchers("/api/cocktails/**").permitAll()
-
+                        .requestMatchers("/user/**").permitAll()
+                        .requestMatchers("/cocktails/**").permitAll()
+                        .requestMatchers("/chatbot/**").permitAll()
 
                         // 회원 or 인증된 사용자만 가능
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-//                        .requestMatchers("/api/cocktail/detail~~").authenticated()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
 
                         //그 외에는 인증해야함
                         .anyRequest().authenticated()
@@ -95,9 +100,8 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:3000",
-                "http://localhost:8080"
-                //나중에 운영환경 추가
+                frontUrl,
+                backUrl
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,7 +19,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         show_sql: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,11 +22,11 @@ spring:
             scope: profile_nickname # 카카오 닉네임만 가져옴
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: '${BASE_URL}/{action}/oauth2/code/{registrationId}'
+            redirect-uri: '${custom.site.backUrl}/{action}/oauth2/code/{registrationId}'
           google:
             client-id: ${GOOGLE_OAUTH2_CLIENT_ID}
             client-secret: ${GOOGLE_OAUTH2_CLIENT_SECRET}
-            redirect-uri: '${BASE_URL}/{action}/oauth2/code/{registrationId}'
+            redirect-uri: '${custom.site.backUrl}/{action}/oauth2/code/{registrationId}'
             client-name: Google
             scope: profile
           naver:
@@ -35,7 +35,7 @@ spring:
             scope: profile_nickname # 네이버 닉네임만 가져옴
             client-name: Naver
             authorization-grant-type: authorization_code
-            redirect-uri: '${BASE_URL}/{action}/oauth2/code/{registrationId}'
+            redirect-uri: '${custom.site.backUrl}/{action}/oauth2/code/{registrationId}'
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -77,10 +77,10 @@ custom:
     frontUrl: "https://www.${custom.prod.cookieDomain}"
     backUrl: "https://api.${custom.prod.cookieDomain}"
   site:
-    cookieDomain: "${custom.dev.cookieDomain}"
-    frontUrl: "${custom.dev.frontUrl}"
-    backUrl: "${custom.dev.backUrl}"
-    name: p-14044-1
+    cookieDomain: ${custom.dev.cookieDomain}
+    frontUrl: ${custom.dev.frontUrl}
+    backUrl: ${custom.dev.backUrl}
+    name: ssoul
   jwt:
     secretKey: ${JWT_SECRET_KEY}
   accessToken:


### PR DESCRIPTION
## 📢 기능 설명

1. 기존 '${BASE_URL}/{action}/oauth2/code/{registrationId}' 은 접두사 api 없이 redirect url 호출

app.yml
<img width="439" height="310" alt="image" src="https://github.com/user-attachments/assets/906cc509-4207-4684-ae32-69281d41edfb" />

app-prod.yml
<img width="312" height="189" alt="image" src="https://github.com/user-attachments/assets/554c553a-a9de-45a3-a2e3-eace63e37717" />

운영환경에서 site.back, front url을 오버라이드 받아 ${custom.site.backUrl}/{action}/oauth2/code/{registrationId}' 에 올바로 매핑

2. 개발 편의성을 위해 db table 설정 update -> create-drop 변경
## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #106 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
