### PR TITLE
[refactor] 세션 기능 삭제 및 JPA only 방식 리팩토링 #113

### DIFF
--- a/src/main/java/com/back/domain/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/back/domain/chatbot/controller/ChatbotController.java
@@ -33,24 +33,10 @@ public class ChatbotController {
         }
     }
 
-    @GetMapping("/history/{sessionId}")
-    public ResponseEntity<RsData<List<ChatConversation>>> getChatHistory(@PathVariable String sessionId) {
+    @GetMapping("/history/user/{userId}")
+    public ResponseEntity<RsData<List<ChatConversation>>> getUserChatHistory(@PathVariable Long userId) {
         try {
-            List<ChatConversation> history = chatbotService.getChatHistory(sessionId);
-            return ResponseEntity.ok(RsData.successOf(history));
-        } catch (Exception e) {
-            log.error("채팅 기록 조회 중 오류 발생: ", e);
-            return ResponseEntity.internalServerError()
-                    .body(RsData.failOf("서버 오류가 발생했습니다."));
-        }
-    }
-
-    @GetMapping("/history/user/{userId}/session/{sessionId}")
-    public ResponseEntity<RsData<List<ChatConversation>>> getUserChatHistory(
-            @PathVariable Long userId,
-            @PathVariable String sessionId) {
-        try {
-            List<ChatConversation> history = chatbotService.getUserChatHistory(userId, sessionId);
+            List<ChatConversation> history = chatbotService.getUserChatHistory(userId);
             return ResponseEntity.ok(RsData.successOf(history));
         } catch (Exception e) {
             log.error("사용자 채팅 기록 조회 중 오류 발생: ", e);

--- a/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
+++ b/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
@@ -13,7 +13,6 @@ public class ChatRequestDto {
     @NotBlank(message = "메시지는 필수입니다.")
     private String message;
 
-    private String sessionId;
 
     private Long userId;
 }

--- a/src/main/java/com/back/domain/chatbot/dto/ChatResponseDto.java
+++ b/src/main/java/com/back/domain/chatbot/dto/ChatResponseDto.java
@@ -14,12 +14,10 @@ import java.time.LocalDateTime;
 public class ChatResponseDto {
 
     private String response;
-    private String sessionId;
     private LocalDateTime timestamp;
 
-    public ChatResponseDto(String response, String sessionId) {
+    public ChatResponseDto(String response) {
         this.response = response;
-        this.sessionId = sessionId;
         this.timestamp = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/back/domain/chatbot/entity/ChatConversation.java
+++ b/src/main/java/com/back/domain/chatbot/entity/ChatConversation.java
@@ -27,8 +27,6 @@ public class ChatConversation {
     @Column(columnDefinition = "TEXT")
     private String botResponse;
 
-    private String sessionId;
-
     private LocalDateTime createdAt;
 
     @PrePersist

--- a/src/main/java/com/back/domain/chatbot/repository/ChatConversationRepository.java
+++ b/src/main/java/com/back/domain/chatbot/repository/ChatConversationRepository.java
@@ -11,11 +11,7 @@ import java.util.List;
 @Repository
 public interface ChatConversationRepository extends JpaRepository<ChatConversation, Long> {
 
-    List<ChatConversation> findBySessionIdOrderByCreatedAtAsc(String sessionId);
-
     Page<ChatConversation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
-
-    List<ChatConversation> findByUserIdAndSessionIdOrderByCreatedAtAsc(Long userId, String sessionId);
 
     List<ChatConversation> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/back/domain/chatbot/repository/ChatConversationRepository.java
+++ b/src/main/java/com/back/domain/chatbot/repository/ChatConversationRepository.java
@@ -16,4 +16,6 @@ public interface ChatConversationRepository extends JpaRepository<ChatConversati
     Page<ChatConversation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     List<ChatConversation> findByUserIdAndSessionIdOrderByCreatedAtAsc(Long userId, String sessionId);
+
+    List<ChatConversation> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
@@ -4,24 +4,24 @@ import com.back.domain.chatbot.dto.ChatRequestDto;
 import com.back.domain.chatbot.dto.ChatResponseDto;
 import com.back.domain.chatbot.entity.ChatConversation;
 import com.back.domain.chatbot.repository.ChatConversationRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.messages.*;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StreamUtils;
 
-import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.*;
-import org.springframework.data.domain.Pageable;
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -199,7 +199,6 @@ public class ChatbotService {
                 .userId(requestDto.getUserId())
                 .userMessage(requestDto.getMessage())
                 .botResponse(response)
-                .sessionId(null)
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
@@ -7,8 +7,6 @@ import com.back.domain.chatbot.repository.ChatConversationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.memory.InMemoryChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.messages.*;
 import org.springframework.ai.openai.OpenAiChatOptions;
@@ -23,7 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.data.domain.Pageable;
 
 @Service
 @RequiredArgsConstructor
@@ -33,8 +31,6 @@ public class ChatbotService {
     private final ChatModel chatModel;
     private final ChatConversationRepository chatConversationRepository;
 
-    // 세션별 메모리 관리 (Thread-Safe)
-    private final ConcurrentHashMap<String, InMemoryChatMemory> sessionMemories = new ConcurrentHashMap<>();
 
     @Value("classpath:prompts/chatbot-system-prompt.txt")
     private Resource systemPromptResource;
@@ -80,23 +76,24 @@ public class ChatbotService {
 
     @Transactional
     public ChatResponseDto sendMessage(ChatRequestDto requestDto) {
-        String sessionId = ensureSessionId(requestDto.getSessionId());
-
         try {
             // 메시지 타입 감지
             MessageType messageType = detectMessageType(requestDto.getMessage());
 
-            // 세션별 메모리 가져오기
-            InMemoryChatMemory chatMemory = getOrCreateSessionMemory(sessionId);
+            // 최근 대화 기록 조회 (최신 5개)
+            List<ChatConversation> recentChats =
+                chatConversationRepository.findTop5ByUserIdOrderByCreatedAtDesc(requestDto.getUserId());
 
-            // 이전 대화 기록 로드
-            loadConversationHistory(sessionId, chatMemory);
+            // 대화 히스토리를 시간순으로 정렬 (오래된 것부터)
+            Collections.reverse(recentChats);
+
+            // 대화 컨텍스트 생성
+            String conversationContext = buildConversationContext(recentChats);
 
             // ChatClient 빌더 생성
             var promptBuilder = chatClient.prompt()
-                    .system(buildSystemMessage(messageType))
-                    .user(buildUserMessage(requestDto.getMessage(), messageType))
-                    .advisors(new MessageChatMemoryAdvisor(chatMemory));
+                    .system(buildSystemMessage(messageType) + conversationContext)
+                    .user(buildUserMessage(requestDto.getMessage(), messageType));
 
             // RAG 기능은 향후 구현 예정 (Vector DB 설정 필요)
 
@@ -109,42 +106,31 @@ public class ChatbotService {
             // 응답 후처리
             response = postProcessResponse(response, messageType);
 
-            // 대화 저장
-            saveConversation(requestDto, response, sessionId);
+            // 대화 저장 (sessionId 없이)
+            saveConversation(requestDto, response);
 
-            return new ChatResponseDto(response, sessionId);
+            return new ChatResponseDto(response, null);
 
         } catch (Exception e) {
             log.error("채팅 응답 생성 중 오류 발생: ", e);
-            return handleError(sessionId, e);
+            return handleError(e);
         }
     }
 
-    private String ensureSessionId(String sessionId) {
-        return (sessionId == null || sessionId.isEmpty())
-                ? UUID.randomUUID().toString()
-                : sessionId;
-    }
 
-    private InMemoryChatMemory getOrCreateSessionMemory(String sessionId) {
-        return sessionMemories.computeIfAbsent(
-                sessionId,
-                k -> new InMemoryChatMemory()
-        );
-    }
+    private String buildConversationContext(List<ChatConversation> recentChats) {
+        if (recentChats.isEmpty()) {
+            return "";
+        }
 
-    private void loadConversationHistory(String sessionId, InMemoryChatMemory chatMemory) {
-        List<ChatConversation> conversations =
-                chatConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        StringBuilder context = new StringBuilder("\n\n【최근 대화 기록】\n");
+        for (ChatConversation chat : recentChats) {
+            context.append("사용자: ").append(chat.getUserMessage()).append("\n");
+            context.append("봇: ").append(chat.getBotResponse()).append("\n\n");
+        }
+        context.append("위 대화를 참고하여 자연스럽게 이어지는 답변을 해주세요.\n");
 
-        // 최근 N개의 대화만 메모리에 로드
-        String sessionIdForMemory = sessionId;
-        conversations.stream()
-                .skip(Math.max(0, conversations.size() - maxConversationCount))
-                .forEach(conv -> {
-                    chatMemory.add(sessionIdForMemory, new UserMessage(conv.getUserMessage()));
-                    chatMemory.add(sessionIdForMemory, new AssistantMessage(conv.getBotResponse()));
-                });
+        return context.toString();
     }
 
     private String buildSystemMessage(MessageType type) {
@@ -208,19 +194,19 @@ public class ChatbotService {
         return response;
     }
 
-    private void saveConversation(ChatRequestDto requestDto, String response, String sessionId) {
+    private void saveConversation(ChatRequestDto requestDto, String response) {
         ChatConversation conversation = ChatConversation.builder()
                 .userId(requestDto.getUserId())
                 .userMessage(requestDto.getMessage())
                 .botResponse(response)
-                .sessionId(sessionId)
+                .sessionId(null)
                 .createdAt(LocalDateTime.now())
                 .build();
 
         chatConversationRepository.save(conversation);
     }
 
-    private ChatResponseDto handleError(String sessionId, Exception e) {
+    private ChatResponseDto handleError(Exception e) {
         String errorMessage = "죄송합니다. 잠시 후 다시 시도해주세요.";
 
         if (e.getMessage().contains("rate limit")) {
@@ -229,7 +215,7 @@ public class ChatbotService {
             errorMessage = "응답 시간이 초과되었습니다. 다시 시도해주세요.";
         }
 
-        return new ChatResponseDto(errorMessage, sessionId);
+        return new ChatResponseDto(errorMessage, null);
     }
 
     public enum MessageType {
@@ -254,25 +240,9 @@ public class ChatbotService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatConversation> getChatHistory(String sessionId) {
-        return chatConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+    public List<ChatConversation> getUserChatHistory(Long userId) {
+        return chatConversationRepository.findByUserIdOrderByCreatedAtDesc(userId, Pageable.unpaged()).getContent();
     }
 
-    @Transactional(readOnly = true)
-    public List<ChatConversation> getUserChatHistory(Long userId, String sessionId) {
-        return chatConversationRepository.findByUserIdAndSessionIdOrderByCreatedAtAsc(userId, sessionId);
-    }
-
-    // 정기적인 메모리 정리 (스케줄러로 호출)
-    public void cleanupInactiveSessions() {
-        long thirtyMinutesAgo = System.currentTimeMillis() - (30 * 60 * 1000);
-
-        sessionMemories.entrySet().removeIf(entry -> {
-            // 실제로는 마지막 사용 시간을 추적해야 함
-            return false;
-        });
-
-        log.info("세션 메모리 정리 완료. 현재 활성 세션: {}", sessionMemories.size());
-    }
 }
 

--- a/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/back/domain/chatbot/service/ChatbotService.java
@@ -109,7 +109,7 @@ public class ChatbotService {
             // 대화 저장 (sessionId 없이)
             saveConversation(requestDto, response);
 
-            return new ChatResponseDto(response, null);
+            return new ChatResponseDto(response);
 
         } catch (Exception e) {
             log.error("채팅 응답 생성 중 오류 발생: ", e);
@@ -215,7 +215,7 @@ public class ChatbotService {
             errorMessage = "응답 시간이 초과되었습니다. 다시 시도해주세요.";
         }
 
-        return new ChatResponseDto(errorMessage, null);
+        return new ChatResponseDto(errorMessage);
     }
 
     public enum MessageType {

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
                         .requestMatchers("/user/**").permitAll()
                         .requestMatchers("/cocktails/**").permitAll()
-                        .requestMatchers("/chatbot/**").permitAll()
+                        .requestMatchers("/api/chatbot/**").permitAll() // test를 위해 /api 추가
 
                         // 회원 or 인증된 사용자만 가능
                         .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
                         .requestMatchers("/user/**").permitAll()
                         .requestMatchers("/cocktails/**").permitAll()
-                        .requestMatchers("/api/chatbot/**").permitAll() // test를 위해 /api 추가
+                        .requestMatchers("/chatbot/**").permitAll()
 
                         // 회원 or 인증된 사용자만 가능
                         .requestMatchers("/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## 📢 기능 설명

세션 관리 로직을 추가할 예정이였으나, 강사님과 상의 후 기존
InmemoryChatmemory + JPA 방식에서 -> JPA Only  방식으로 변경
이에 따라 세션 기능 삭제 
<br>

## 연결된 issue


close #113 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

[x] 엔드포인트 일부 변경 : sessionId 를 통한 조회 삭제 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
