### PR TITLE
[fix] chatbot 도메인 currentStep 관련 문제 해결 #227

### DIFF
--- a/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
+++ b/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
@@ -18,7 +18,8 @@ public class ChatRequestDto {
     // 단계별 추천 관련 필드들
     private boolean isStepRecommendation = false;
     private Integer currentStep;
-    private String selectedAlcoholStrength;  // "ALL" 처리를 위해 스텝 3개 String으로 변경
+    // "ALL" 처리를 위해 스텝 3개 String으로 변경
+    private String selectedAlcoholStrength;
     private String selectedAlcoholBaseType;
     private String selectedCocktailType;
 }

--- a/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
+++ b/src/main/java/com/back/domain/chatbot/dto/ChatRequestDto.java
@@ -16,7 +16,12 @@ public class ChatRequestDto {
     private Long userId;
 
     // 단계별 추천 관련 필드들
+    /**
+     * @deprecated currentStep 필드를 사용하세요. 이 필드는 하위 호환성을 위해 유지됩니다.
+     */
+    @Deprecated
     private boolean isStepRecommendation = false;
+
     private Integer currentStep;
     // "ALL" 처리를 위해 스텝 3개 String으로 변경
     private String selectedAlcoholStrength;


### PR DESCRIPTION
## 📢 기능 설명
  주요 변경사항

  1. ChatbotService.java:90 - 3단계 우선순위 로직

  // 1순위: currentStep 명시적 제어
  - currentStep == 0 → 질문형 추천
  - currentStep 1~4 → 단계별 추천
  - 그 외 → 에러 응답

  // 2순위: 키워드 감지 (레거시)
  - "단계별 추천" 키워드 감지 시 자동으로 currentStep=1 설정

  // 3순위: 기본 일반 대화

  2. 새로운 메서드

  - ChatbotService.java:437 - generateAIResponseWithContext() - 질문형 추천 전용
  - ChatbotService.java:455 - createErrorResponse() - 에러 응답 생성

  3. 로깅 전략

  - [EXPLICIT] - currentStep 명시적 사용
  - [LEGACY] - 키워드 기반 감지 (deprecated)
  - [DEFAULT] - 일반 대화 모드

  4. Deprecated 처리

  - ChatRequestDto.java:22 - isStepRecommendation 필드
  - ChatbotService.java:427 - isStepRecommendationTrigger() 메서드


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #227 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
