### PR TITLE
[refactor] 댓글삭제 관련 소프트 delete이후 댓글 작성 가능하도록 기능개선 #273

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    testImplementation("org.springframework.batch:spring-batch-test")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/com/back/domain/cocktail/comment/entity/CocktailComment.java
+++ b/src/main/java/com/back/domain/cocktail/comment/entity/CocktailComment.java
@@ -15,10 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(
-        name = "cocktail_comment",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"cocktail_id", "user_id"}) // 사용자 1개 댓글 제한
-)
+@Table(name = "cocktail_comment")
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/src/main/java/com/back/domain/cocktail/comment/repository/CocktailCommentRepository.java
+++ b/src/main/java/com/back/domain/cocktail/comment/repository/CocktailCommentRepository.java
@@ -1,6 +1,7 @@
 package com.back.domain.cocktail.comment.repository;
 
 import com.back.domain.cocktail.comment.entity.CocktailComment;
+import com.back.domain.post.comment.enums.CommentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +14,5 @@ public interface CocktailCommentRepository extends JpaRepository<CocktailComment
 
     List<CocktailComment> findTop10ByCocktailIdAndIdLessThanOrderByIdDesc(Long cocktailId, Long lastId);
 
-    boolean existsByCocktailIdAndUserId(Long cocktailId, Long id);
+    boolean existsByCocktailIdAndUserIdAndStatusNot(Long cocktailId, Long id, CommentStatus status);
 }

--- a/src/main/java/com/back/domain/cocktail/comment/service/CocktailCommentService.java
+++ b/src/main/java/com/back/domain/cocktail/comment/service/CocktailCommentService.java
@@ -32,7 +32,12 @@ public class CocktailCommentService {
                 .orElseThrow(() -> new IllegalArgumentException("칵테일이 존재하지 않습니다. id=" + cocktailId));
 
         // 사용자당 댓글 1개 제한 체크
-        boolean exists = cocktailCommentRepository.existsByCocktailIdAndUserId(cocktailId, user.getId());
+        boolean exists = cocktailCommentRepository.existsByCocktailIdAndUserIdAndStatusNot(
+                cocktailId,
+                user.getId(),
+                CommentStatus.DELETED // DELETED 상태는 제외하고 검사
+        );
+
         if (exists) {
             throw new IllegalArgumentException("이미 댓글을 작성하셨습니다.");
         }


### PR DESCRIPTION
## 📢 기능 설명

댓글삭제 관련 소프트 delete이후 댓글 작성 가능하도록 기능개선

<img width="868" height="251" alt="image" src="https://github.com/user-attachments/assets/cc23e70b-4fc0-4c6c-85f9-ae9281a698f7" />

## 연결된 issue

close #273 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 댓글삭제 관련 소프트 delete이후 댓글 작성 가능하도록 기능개선

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?

