### PR TITLE
[fix] 커뮤니티 이미지 데이터가 빈 배열로 들어가는 문제 수정#298

### DIFF
--- a/src/main/java/com/back/domain/post/post/entity/Post.java
+++ b/src/main/java/com/back/domain/post/post/entity/Post.java
@@ -115,6 +115,15 @@ public class Post {
     this.content = content;
   }
 
+  public void addImage(PostImage image) {
+    if (this.images == null) {
+      this.images = new ArrayList<>();
+    }
+    this.images.add(image);
+    image.updatePost(this); // 양방향 관계 유지
+  }
+
+
   public void updateImages(List<PostImage> images) {
     this.images.clear();
     for (PostImage i : images) {

--- a/src/main/java/com/back/domain/post/post/service/PostService.java
+++ b/src/main/java/com/back/domain/post/post/service/PostService.java
@@ -79,13 +79,12 @@ public class PostService {
         String url = fileService.uploadFile(image);
 
         PostImage postImage = PostImage.builder()
-            .post(post)
             .fileName(image.getOriginalFilename())
             .url(url)
             .sortOrder(order++)
             .build();
 
-        postImageRepository.save(postImage);
+        post.addImage(postImage);
       }
     }
 


### PR DESCRIPTION
## 📢 기능 설명

커뮤니티 이미지 데이터가 빈 배열로 들어가는 문제 수정
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #298 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 커뮤니티 이미지 데이터가 빈 배열로 들어가는 문제 수정

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
