### PR TITLE
[fix] : 칵테일 상세페이지 로그인 401 오류, CocktailSummaryResponseDto keepCount, commentCount 추가

### DIFF
--- a/src/main/java/com/back/domain/cocktail/comment/repository/CocktailCommentRepository.java
+++ b/src/main/java/com/back/domain/cocktail/comment/repository/CocktailCommentRepository.java
@@ -1,6 +1,7 @@
 package com.back.domain.cocktail.comment.repository;
 
 import com.back.domain.cocktail.comment.entity.CocktailComment;
+import com.back.domain.cocktail.entity.Cocktail;
 import com.back.domain.post.comment.enums.CommentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -19,4 +20,6 @@ public interface CocktailCommentRepository extends JpaRepository<CocktailComment
     );
 
     boolean existsByCocktailIdAndUserIdAndStatusNot(Long cocktailId, Long id, CommentStatus status);
+
+    Long countByCocktail(Cocktail cocktail);
 }

--- a/src/main/java/com/back/domain/cocktail/dto/CocktailSummaryResponseDto.java
+++ b/src/main/java/com/back/domain/cocktail/dto/CocktailSummaryResponseDto.java
@@ -1,21 +1,22 @@
 package com.back.domain.cocktail.dto;
 
-import com.back.domain.cocktail.entity.Cocktail;
-
 public record CocktailSummaryResponseDto(
         Long cocktailId,
         String cocktailName,
         String cocktailNameKo,
         String cocktailImgUrl,
-        String alcoholStrength // Enum 대신 String
+        String alcoholStrength,
+        Long keepCount,
+        Long commentCount
 ) {
-    public CocktailSummaryResponseDto(Cocktail cocktail) {
-        this(
-                cocktail.getId(),
-                cocktail.getCocktailName(),
-                cocktail.getCocktailNameKo(),
-                cocktail.getCocktailImgUrl(),
-                cocktail.getAlcoholStrength().getDescription() // 설명으로 변환
-        );
+
+   //5개 필드만 사용하는 경우 (keepCount, commentCount 기본값 0)
+
+    public CocktailSummaryResponseDto(Long cocktailId,
+                                      String cocktailName,
+                                      String cocktailNameKo,
+                                      String cocktailImgUrl,
+                                      String alcoholStrength) {
+        this(cocktailId, cocktailName, cocktailNameKo, cocktailImgUrl, alcoholStrength, 0L, 0L);
     }
 }

--- a/src/main/java/com/back/domain/mybar/repository/MyBarRepository.java
+++ b/src/main/java/com/back/domain/mybar/repository/MyBarRepository.java
@@ -1,5 +1,6 @@
 package com.back.domain.mybar.repository;
 
+import com.back.domain.cocktail.entity.Cocktail;
 import com.back.domain.mybar.entity.MyBar;
 import com.back.domain.mybar.enums.KeepStatus;
 import org.springframework.data.domain.Page;
@@ -9,9 +10,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.List;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MyBarRepository extends JpaRepository<MyBar, Long> {
@@ -56,4 +57,7 @@ public interface MyBarRepository extends JpaRepository<MyBar, Long> {
            and m.status = 'ACTIVE'
     """)
     int softDeleteByUserAndCocktail(Long userId, Long cocktailId);
+
+    // 특정 칵테일의 ACTIVE Keep 개수
+    Long countByCocktailAndStatus(Cocktail cocktail, KeepStatus status);
 }


### PR DESCRIPTION
## 📢 기능 설명

칵테일 상세페이지 로그인 401 오류, CocktailSummaryResponseDto keepCount, commentCount 추가

## 연결된 issue


close #323 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 칵테일 상세페이지 로그인 401 오류
- [x] CocktailSummaryResponseDto keepCount, commentCount 추가

<br>

## ✅ 체크리스트

- [X] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
